### PR TITLE
Space in deploy changed to service manual and app name changed

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,7 +18,7 @@ jobs:
       with: 
         CF_USERNAME: ${{ secrets.CF_USERNAME }}
         CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-        CF_SPACE_NAME: sandbox
+        CF_SPACE_NAME: dfe-service-manual-prod
 
     - name: Push to GOV.UK PaaS
-      run: cf push -b ruby_buildpack -c 'bundle exec rails server -b 0.0.0.0' --strategy rolling service-manual
+      run: cf push -b ruby_buildpack -c 'bundle exec rails server -b 0.0.0.0' --strategy rolling service-manual-prod


### PR DESCRIPTION
### Context

- Changes made to the deploy configuration since the new service manual space has been set up

### Changes proposed in this pull request

- Space name changed to `dfe-service-manual-prod` 
- App name changed to `service-manual-prod`

### Guidance to review

